### PR TITLE
Fix unprivileged user can edit roles.

### DIFF
--- a/app/Http/Controllers/RolesController.php
+++ b/app/Http/Controllers/RolesController.php
@@ -17,7 +17,7 @@ class RolesController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('user.is.admin', ['only' => ['index', 'create', 'destroy']]);
+        $this->middleware('user.is.admin', ['only' => ['index', 'create', 'destroy', 'show', 'update']]);
     }
 
     /**

--- a/tests/Unit/Controllers/Role/RoleControllerTest.php
+++ b/tests/Unit/Controllers/Role/RoleControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Controllers\Role;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
+
+class RoleControllerTest extends TestCase
+{
+//    use DatabaseTransactions, WithoutMiddleware;
+
+    /** @test */
+    public function unprivileged_user_cannot_change_permissions()
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user);
+
+        /** @var Role $role */
+        $role = factory(Role::class)->create();
+        $user->roles()->save($role);
+
+        $this->get("/roles/{$role->external_id}")
+            ->assertRedirect()
+            ->assertSessionHas('flash_message_warning');
+
+        $this->patch("/roles/update/{$role->external_id}")
+            ->assertRedirect()
+            ->assertSessionHas('flash_message_warning');
+    }
+}

--- a/tests/Unit/Controllers/Role/RoleControllerTest.php
+++ b/tests/Unit/Controllers/Role/RoleControllerTest.php
@@ -13,7 +13,7 @@ class RoleControllerTest extends TestCase
 //    use DatabaseTransactions, WithoutMiddleware;
 
     /** @test */
-    public function unprivileged_user_cannot_change_permissions()
+    public function unprivileged_user_cannot_change_roles()
     {
         /** @var User $user */
         $user = factory(User::class)->create();


### PR DESCRIPTION
Currently, an unprivileged user can edit roles and promote himself to the administrator. 