### PR TITLE
Resolves #191: Use file, not memcached, as default cache driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ DB_DATABASE=database
 DB_USERNAME=username
 DB_PASSWORD=password
 
-CACHE_DRIVER=array
+CACHE_DRIVER=file
 SESSION_DRIVER=file
 QUEUE_DRIVER=sync
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_DRIVER', 'memcached'),
+    'default' => env('CACHE_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Per issue 191, suggest changing the default cache driver to file, not memcached.