### PR TITLE
Fix: Error - task list - tasks without assigned project

### DIFF
--- a/app/Http/Controllers/TasksController.php
+++ b/app/Http/Controllers/TasksController.php
@@ -52,11 +52,10 @@ class TasksController extends Controller
 
     public function anyData()
     {
-        $tasks = Task::with(['user', 'status'])->select(
-            collect(['external_id', 'title', 'created_at', 'deadline', 'user_assigned_id', 'status_id'])
+        $tasks = Task::with(['user', 'status', 'client'])->select(
+            collect(['external_id', 'title', 'created_at', 'deadline', 'user_assigned_id', 'status_id', 'client_id'])
                 ->map(function ($field) {
-                    $tablePrefix = (new Task())->getTable();
-                    return "$tablePrefix.$field";
+                    return (new Task())->qualifyColumn($field);
                 })
                 ->all()
         );

--- a/tests/Unit/Controllers/Task/TasksControllerTest.php
+++ b/tests/Unit/Controllers/Task/TasksControllerTest.php
@@ -122,4 +122,15 @@ class TasksControllerTest extends TestCase
 
         $this->assertEquals(Carbon::parse('2020-08-06')->toDate(), $task->refresh()->deadline->toDate());
     }
+
+    /** @test */
+    public function can_list_tasks()
+    {
+        factory(Task::class)->create();
+
+        $error = $this->json('GET', route('tasks.data'))
+            ->assertSuccessful()
+            ->json('error');
+        $this->assertNull($error);
+    }
 }


### PR DESCRIPTION
See #217.

During merge conflict resolving in https://github.com/Bottelet/DaybydayCRM/commit/4a837c5c27a4c80fd2c6594e0a2ad4b25ff24da7 `client_id` field was lost. That led to the error described in the issue. 

Regards

