### PR TITLE
Filesystem public disk

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -48,6 +48,13 @@ return [
             'root'   => storage_path('app'),
         ],
 
+        'public' => [
+            'driver'     => 'local',
+            'root'       => storage_path('app/public'),
+            'url'        => env('APP_URL') . '/storage',
+            'visibility' => 'public',
+        ],
+
         'ftp' => [
             'driver'   => 'ftp',
             'host'     => 'ftp.example.com',

--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This pr adds support for the [public disk](https://laravel.com/docs/7.x/filesystem#the-public-disk).

The public disk is useful when running the code locally.

Related to #214