### PR TITLE
Fix docker db error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,6 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=daybyday
-      - MYSQL_USER=root
-      - MYSQL_PASSWORD=root
     networks:
       - service_net
 


### PR DESCRIPTION
Fix docker db error

```
dbMain            |     Remove MYSQL_USER="root" and use one of the following to control the root user password:
dbMain            |     - MYSQL_ROOT_PASSWORD
dbMain            |     - MYSQL_ALLOW_EMPTY_PASSWORD
dbMain            |     - MYSQL_RANDOM_ROOT_PASSWORD
```